### PR TITLE
Cleanup Dangling Files and State Entries After Delete (Issue #2)

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -84,6 +84,11 @@ impl State {
         let hash = hashed_password(password, &user.password_salt);
         (hash == user.password_hash).then_some(user)
     }
+
+    /// Returns a mutable iterator over all users (for cleanup purposes)
+    pub fn users_mut(&mut self) -> impl Iterator<Item = &mut User> {
+        self.users.values_mut()
+    }
 }
 
 fn hashed_password(password: &str, salt: &str) -> Vec<u8> {


### PR DESCRIPTION
This PR addresses issue #2:
> Removing the file from disk and from the state is not an atomic operation. If one of them fails, there will be either a dangling reference (file visible in the state but not existing on disk) or dangling file (same as anonymous file in current implementation).